### PR TITLE
Month -1 offset fix

### DIFF
--- a/selection.js
+++ b/selection.js
@@ -50,11 +50,11 @@ function timestampToDate(ts) {
 
 function getLocalString(date) {
   tz = date.getTimezoneOffset()
-  return `${date.getFullYear()}-${pad(date.getMonth())}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())} GMT${tz < 0 ? '+' : '-'}${pad(Math.floor(tz / 60))}:${pad(tz % 60)}`
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())} GMT${tz < 0 ? '+' : '-'}${pad(Math.floor(tz / 60))}:${pad(tz % 60)}`
 }
 
 function getUTCString(date) {
-  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth())}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())} GMT`
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())} GMT`
 }
 
 function pad(v) {


### PR DESCRIPTION
`date.getUTCMonth()` and `date.getMonth()` are zero-based, causing months tin the converted date to be offset by -1. Therefore 1 Jan 1970 becomes 1970-00-01, etc. 

This simple fix negates the offset